### PR TITLE
fix: missing napi label in linux-x64 filename

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ export class Skia extends Service {
         arm64: `darwin-arm64-${napiLabel}-unknown`
       },
       linux: {
-        x64: `linux-x64-${this.isMusl() ? 'musl' : 'glibc'}`,
+        x64: `linux-x64-${napiLabel}-${this.isMusl() ? 'musl' : 'glibc'}`,
         arm64: this.isMusl() ? `linux-arm64-${napiLabel}-musl` : '',
         arm: `linux-arm-${napiLabel}-glibc`
       }


### PR DESCRIPTION
This should be `https://registry.npmmirror.com/-/binary/skia-canvas/v1.0.1/linux-x64-napi-v6-musl.tar.gz`, `https://registry.npmmirror.com/-/binary/skia-canvas/v1.0.1/linux-x64-musl.tar.gz` is 404.